### PR TITLE
Make Some field optional to pass Market order

### DIFF
--- a/binance.go
+++ b/binance.go
@@ -266,6 +266,7 @@ type NewOrderRequest struct {
 	StopPrice        float64
 	IcebergQty       float64
 	Timestamp        time.Time
+	MinQuantity      float64
 }
 
 // ProcessedOrder represents data from processed order.

--- a/service_account.go
+++ b/service_account.go
@@ -29,9 +29,13 @@ func (as *apiService) NewOrder(or NewOrderRequest) (*ProcessedOrder, error) {
 	params["symbol"] = or.Symbol
 	params["side"] = string(or.Side)
 	params["type"] = string(or.Type)
-	params["timeInForce"] = string(or.TimeInForce)
+	if len(or.TimeInForce) > 0 {
+		params["timeInForce"] = string(or.TimeInForce)
+	}
 	params["quantity"] = strconv.FormatFloat(or.Quantity, 'f', -1, 64)
-	params["price"] = strconv.FormatFloat(or.Price, 'f', -1, 64)
+	if or.Price > 0 {
+		params["price"] = strconv.FormatFloat(or.Price, 'f', -1, 64)
+	}
 	params["timestamp"] = strconv.FormatInt(unixMillis(or.Timestamp), 10)
 	if or.NewClientOrderID != "" {
 		params["newClientOrderId"] = or.NewClientOrderID

--- a/service_account.go
+++ b/service_account.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"encoding/json"
 	"io/ioutil"
+	"math"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -32,7 +33,11 @@ func (as *apiService) NewOrder(or NewOrderRequest) (*ProcessedOrder, error) {
 	if len(or.TimeInForce) > 0 {
 		params["timeInForce"] = string(or.TimeInForce)
 	}
-	params["quantity"] = strconv.FormatFloat(or.Quantity, 'f', -1, 64)
+	if or.MinQuantity > 0 {
+		params["quantity"] = strconv.FormatFloat(or.Quantity, 'f', int(math.Log10(1/or.MinQuantity)), 64)
+	} else {
+		params["quantity"] = strconv.FormatFloat(or.Quantity, 'f', -1, 64)
+	}
 	if or.Price > 0 {
 		params["price"] = strconv.FormatFloat(or.Price, 'f', -1, 64)
 	}


### PR DESCRIPTION
According documentation:
https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-order--trade
We have only few mandatory fileds for MARKET request.
But  fields is not optional in `func NewOrder`.
And request looks like
```
curl -H "X-MBX-APIKEY: *****" -X POST 'https://api.binance.com/api/v3/order' -d 'symbol=LTCBTC&side=BUY&type=MARKET&timeInForce=&quantity=1&price=&recvWindow=&timestamp=1499827319559&signature=****'
````
 Binance backed does not accept empty fields and response error.
