### PR TITLE
Avoid side effect on Ping() fn

### DIFF
--- a/service_market.go
+++ b/service_market.go
@@ -16,7 +16,6 @@ func (as *apiService) Ping() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%#v\n", response.StatusCode)
 	return nil
 }
 


### PR DESCRIPTION
The Ping() fn prints a 200 on os.Stdout that IMHO is a unpleasant side effect.

I took the liberty to remove the `fmt.Println(..)` call.

Please review :)