### PR TITLE
Fix time in rest api

### DIFF
--- a/service_market.go
+++ b/service_market.go
@@ -32,12 +32,12 @@ func (as *apiService) Time() (time.Time, error) {
 	}
 	defer res.Body.Close()
 	var rawTime struct {
-		ServerTime string `json:"serverTime"`
+		ServerTime float64 `json:"serverTime"`
 	}
 	if err := json.Unmarshal(textRes, &rawTime); err != nil {
 		return time.Time{}, errors.Wrap(err, "timeResponse unmarshal failed")
 	}
-	t, err := timeFromUnixTimestampFloat(rawTime)
+	t, err := timeFromUnixTimestampFloat(rawTime.ServerTime)
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
```
var rawTime struct {
    ServerTime string `json:"serverTime"`
}
```
In rawTime struct, the return value of ServerTime is not string, I improve it to this:
```
var rawTime struct {
    ServerTime float64 `json:"serverTime"`
}
```